### PR TITLE
Feat jstat udf

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Google LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To contribute UDFs to this repository, see the
 
 ## License
 
-All solutions within this repository are provided under the
+Except as otherwise noted, the solutions within this repository are provided under the
 [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license. Please see
 the [LICENSE](/LICENSE) file for more detailed terms and conditions.
 

--- a/dataform/examples/dataform_assertion_unit_test/.gitignore
+++ b/dataform/examples/dataform_assertion_unit_test/.gitignore
@@ -1,0 +1,3 @@
+.df-credentials.json
+node_modules/
+package-lock.json

--- a/dataform/examples/dataform_assertion_unit_test/README.md
+++ b/dataform/examples/dataform_assertion_unit_test/README.md
@@ -1,0 +1,60 @@
+# Dataform Custom Assertions
+Dataform is a platform to manage data in Big Query and other data warehouses and dataform perform the **T (Transformation)** in the **ELT** Pipeline. But before any transformaiton can be done, we need to make sure our input data is valid. Dataform has many built in data assertions such as uniqueKey, nonNull, and etc. But you can also customize your dataform assertions to meet individual's needs. This directory gives you a set of custom assertions that you can use in testing your data quailty in your project.
+## Requirement 
+In order to test and run the custom dataform assertions, the person has to have have: 
+- A dataform project
+- Credentials granting access to bigquery warehouse .df-credentials
+
+## Usage
+The custom assertions are in javascript files in the includes folder. To test them, simply refer to the function in your transformation query. For example, if a person wants to use the ```test_telephone_number_digits(colName)``` assertions in the ```phone_assertions.js``` file, the person only needs to refer in the config section of the transformation query like:
+
+```
+    type: ....,
+    schema: .....,
+    name: ....,
+    assertions: {
+        nonNull: ["phone_number"],
+        rowConditions: 
+        [
+            phone_assertions.test_telephone_number_digits("phone_nunber")
+        ]
+    }
+```
+## Unit Testing Custom Assertions
+Unit testing your custom assertions is important because it helps you safeguard your ELT pipeline. In this project, we want to demonstrate an easy way for you to unit test your custom assertions. The workflow is simple and as listed below:
+
+* Create a ```test_[NAME_YOUR_TEST]_assertions.js``` file in the ```definitions/tests/``` folder if your custom row assertions are not included in the existing template.
+* In ```test_[NAME_YOUR_TEST]_assertions.js``` change the code snippets ```const {[YOUR_CUSTOM_ASSERTION]} = [CUSTOMER_ASSERTION_FILE_NAME];``` and change the test name ```const test_name = "[YOUR_TEST_NAME]";```. 
+* Add the testing data in the ```test_cases``` block with the following format ```"[INPUT]" : "[EXPECTED_OUTPUT]"```
+* Finally supply your custom function name in the ```generatetest(...)``` function. 
+
+Below is an example of the ```test_[NAME_YOUR_TEST]_assertions.js``` file:
+
+```
+const {generate_test} = unit_test_utils;
+const {[YOUT_CUSTOM_ASSERTIONS]} = [CUSTOM_ASSERTION_FILE_NAME];
+const test_name = "[YOUR_TEST_NAME]";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    "[INPUT1]" : [EXPECTED_OUTPUT]"
+    "[INPUT2]" : [EXPECTED_OUTPUT]"
+    .
+    .
+    .
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    [YOUT_CUSTOM_ASSERTIONS]);
+```
+
+* Afterwards you can perform the unit test by running ```dataform test``` command. 
+ 
+## Liscense
+All solutions within this repository are provided under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license. Please see the [LICENSE](https://www.apache.org/licenses/LICENSE-2.0) file for more detailed terms and conditions.

--- a/dataform/examples/dataform_assertion_unit_test/dataform.json
+++ b/dataform/examples/dataform_assertion_unit_test/dataform.json
@@ -1,0 +1,7 @@
+{
+    "warehouse": "bigquery",
+    "defaultSchema": "dataform",
+    "assertionSchema": "dataform_assertions",
+    "defaultDatabase": "YOUR_PROJECT_ID",
+    "useRunCache": false
+}

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_date_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_date_assertions.js
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_date} = date_assertions;
+const test_name = "test_date_assertions";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+   "1997/11/03" : "TRUE",
+   "2008/08/08" : "TRUE",
+   "1996/11/03" : "TRUE",
+   "2005/04/13" : "TRUE",
+   "1998/11/03" : "TRUE",
+   "2006/07/29" : "TRUE",
+   "2025/03/24" : "FALSE",
+   "1769/03/24" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    test_date);
+    

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_email_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_email_assertions.js
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_email_validity} = personal_info_assertions;
+const test_name = "test_email_assertion_test";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+    "ruinanliu@google.com" : "TRUE",
+    "among.us@amongus.net" : "TRUE",
+    "1736#$%.com" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    test_email_validity);
+    

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_gender_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_gender_assertions.js
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_gender_status} = personal_info_assertions;
+const test_name = "test_gemder_assertions";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+    "Female" : "TRUE",
+    "Male" : "TRUE",
+    "one" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    test_gender_status);
+    

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_marital_status_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_marital_status_assertions.js
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_marital_status} = personal_info_assertions;
+const test_name = "test_marital_status_assertions";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+   "Married" : "TRUE",
+   "Divorced" : "TRUE",
+   "Happy" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    test_marital_status);
+    

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_personal_info_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_personal_info_assertions.js
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_name} = personal_info_assertions;
+const test_file_name = "test_personal_info_assertions";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+   "Alan" : "TRUE",
+   "Bob" : "TRUE",
+   "Jack" : "TRUE",
+   "John" : "TRUE",
+   "y*(*&^^%$" : "FALSE",
+   "Alannnn" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_file_name,
+    test_cases,
+    test_name);
+    

--- a/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_telephone_number_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/definitions/tests/test_telephone_number_assertions.js
@@ -1,0 +1,44 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {generate_test} = unit_test_utils;
+const {test_phone_number} = phone_assertions;
+const test_name = "test_telephone_number_assertions";
+const test_cases = {
+    /*
+        Provide your own testing data following the structure
+        <INPUT_TESTING_DATA> : "<EXPECTED OUTCOME>"
+        For example, if a testing data has the <EXPECTED OUTCOME> to be TRUE,
+        then the program will expect the custom data quality rules to also produce TRUE. 
+        Otherwise it will show that the custom data quality rules failed. 
+    */
+    
+   "8123456789" : "TRUE",
+   "1234567899" : "TRUE",
+   "5123456789" : "TRUE",
+   "4576839485" : "TRUE",
+   "2938475638" : "TRUE",
+   "7928374657" : "TRUE",
+   "7847563738" : "TRUE",
+   "6768907654" : "TRUE",
+   "1234567" : "FALSE",
+   "0123456789" : "FALSE",
+   "1111111111" : "FALSE",
+   "374657389a" : "FALSE"
+};
+// The function below will generate the necessary SQL to run unit tests.
+generate_test(test_name,
+    test_cases,
+    test_phone_number);
+    

--- a/dataform/examples/dataform_assertion_unit_test/includes/date_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/includes/date_assertions.js
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+    This assertion checks whether input date is future
+*/
+function test_future_date(colName){
+    var result_query = `PARSE_DATE('%Y/%m/%d', ${colName}) < CURRENT_DATE()`
+    return result_query
+}
+
+/*
+    This assertion checks whether the input birthdate is less than 100 yrs old
+*/
+function test_valid_years(colName){
+    var result_query = `DATE_DIFF(CURRENT_DATE(), PARSE_DATE('%Y/%m/%d', ${colName}), YEAR) < 100`
+    return result_query
+}
+
+/*
+    This function checks whether the format of  the date is correct
+*/
+function test_date_format(colName, date_format){
+        if(date_format == "yyyy/mm/dd"){
+            var result_query = `REGEXP_CONTAINS(${colName}, r'^[0-9]{4}[/][0-9]{2}[/][0-9]{2}$')`
+            return result_query
+        } else if (date_format == "yyyymmdd"){
+            var result_query = `REGEXP_CONTAINS(${colName}, r'^[0-9]{4}[0-9]{2}[0-9]{2}$')`
+            return result_query
+        }else{
+            return `FALSE`
+        }
+}
+
+/*
+    This assertions combines custom assertions for testing future date and valid years
+*/
+
+function test_date(colName){
+    var result_query =
+    `IF(${colName} IS NOT NULL AND ${colName} <> "",` +
+        `IF(${test_date_format(colName, "yyyy/mm/dd")}, ` +
+            `IF(${test_future_date(colName)}, ` +
+                `${test_valid_years(colName, 100)}` +
+                `, FALSE),` +
+            `IF(${test_date_format(colName, "yyyymmdd")}, ` +
+            `TRUE, FALSE)), FALSE)`
+    return result_query
+}
+
+module.exports = {
+    test_future_date,
+    test_valid_years,
+    test_date_format,
+    test_date
+}

--- a/dataform/examples/dataform_assertion_unit_test/includes/personal_info_assertions.js
+++ b/dataform/examples/dataform_assertion_unit_test/includes/personal_info_assertions.js
@@ -1,0 +1,107 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* 
+This assertion checks whether the input email format is valid
+*/
+function test_email_validity(colName){
+    var result_query = `REGEXP_CONTAINS(${colName}, r'^[\\w.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$')`
+    return result_query
+}
+
+/*
+    This assertion checks whether the input marital status is within an acceptable list 
+*/
+function test_marital_status(colName){
+    var marital_list = "'Married', 'Single', 'Divorced', 'Widowed'"
+    var result_query = `${colName} IN(${marital_list})`
+    return result_query
+}
+
+/*
+    This assertion checks whether the input gender status is within an acceptable list
+*/
+function test_gender_status(colName){
+    var gender_list = "'Female','Male','Transgender Female','Transgender Male','Gender Variant','Prefer Not to Say'"
+    var result_query = `${colName} IN (${gender_list})`
+    return result_query
+}
+
+/*
+    This assertion checks whether the name is valid and only contain characters and numbers
+*/
+function test_name_validity(colName){
+    var result_query = `REGEXP_CONTAINS(${colName}, r'^[a-zA-Z]+$')`
+    return result_query
+}
+
+/*
+    This assertions compares with other input column to check whether the last name is unique
+*/
+function test_last_name_unique(colName1, colName2){
+    var result_query = `${colName1} != ${colName2}`
+    return result_query
+}
+
+/*
+    The assertion checks that no name contain more than n repeated characters 
+*/
+function test_same_character_not_more_than_n_times(colName, n_times){
+    var regex = `(A{${n_times + 1},})+|` +
+                `(B{${n_times + 1},})+|` +
+                `(C{${n_times + 1},})+|` +
+                `(D{${n_times + 1},})+|` +
+                `(E{${n_times + 1},})+|` +
+                `(F{${n_times + 1},})+|` +
+                `(G{${n_times + 1},})+|` +
+                `(H{${n_times + 1},})+|` +
+                `(I{${n_times + 1},})+|` +
+                `(J{${n_times + 1},})+|` +
+                `(K{${n_times + 1},})+|` +
+                `(L{${n_times + 1},})+|` +
+                `(M{${n_times + 1},})+|` +
+                `(N{${n_times + 1},})+|` +
+                `(O{${n_times + 1},})+|` +
+                `(P{${n_times + 1},})+|` +
+                `(Q{${n_times + 1},})+|` +
+                `(R{${n_times + 1},})+|` +
+                `(S{${n_times + 1},})+|` +
+                `(T{${n_times + 1},})+|` +
+                `(U{${n_times + 1},})+|` +
+                `(V{${n_times + 1},})+|` +
+                `(W{${n_times + 1},})+|` +
+                `(X{${n_times + 1},})+|` +
+                `(Y{${n_times + 1},})+|` +
+                `(Z{${n_times + 1},})+`
+    var query_result = `NOT REGEXP_CONTAINS(UPPER(${colName}), r'${regex}')`
+    return query_result
+}
+
+/*
+    This assertions combines custom assertions for names
+ */
+function test_name(colName, n_times){
+    var result_query = `${test_name_validity(colName)} AND ${test_same_character_not_more_than_n_times(colName, 3)}`
+    return result_query
+}
+
+module.exports = {
+    test_email_validity,
+    test_marital_status,
+    test_gender_status,
+    test_name_validity,
+    test_last_name_unique,
+    test_same_character_not_more_than_n_times,
+    test_name
+}

--- a/dataform/examples/dataform_assertion_unit_test/includes/unit_test_utils.js
+++ b/dataform/examples/dataform_assertion_unit_test/includes/unit_test_utils.js
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function generate_test(test_name, test_cases, data_quality_function){
+    publish(test_name)
+        .type("view")
+        .query(ctx => `
+            SELECT
+              ${data_quality_function("test_input")} AS is_valid
+            FROM ${ctx.resolve("test_inputs")}
+        `);
+
+    let expected_output_select_statements = [];
+    let test_input_select_statements = [];
+    for(var test_case in test_cases) {
+        test_input_select_statements.push(`SELECT "${test_case}" AS test_input`);
+        expected_output_select_statements.push(`SELECT ${test_cases[test_case]} AS is_valid`);
+    };
+
+    test(test_name)
+        .dataset(test_name)
+        .input("test_inputs", `${test_input_select_statements.join(' UNION ALL\n')}`)
+        .expect(`${expected_output_select_statements.join(' UNION ALL\n')}`);
+}
+
+module.exports = {
+    generate_test,
+}

--- a/dataform/examples/dataform_assertion_unit_test/package.json
+++ b/dataform/examples/dataform_assertion_unit_test/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "@dataform/core": "1.18.0"
+    }
+}

--- a/udfs/community/jstat.sql
+++ b/udfs/community/jstat.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ARRAY<FLOAT64>)
+RETURNS FLOAT64
+LANGUAGE js AS """
+    const methodPath = method['split']('.')
+    let fn = jstat['jStat']
+    for (const name of methodPath){
+        fn = fn[name]
+    }
+
+  return fn(...args)
+"""
+OPTIONS (
+	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
+);

--- a/udfs/community/test_cases.yaml
+++ b/udfs/community/test_cases.yaml
@@ -411,6 +411,10 @@ levenshtein:
 #
 # Below targets StatsLib work
 #
+jstat:
+  - test:
+    input: CAST('chisquare.cdf' AS STRING), ARRAY<FLOAT64>[0.3, 2.0]
+    expected_output: CAST(0.1392920235749422 AS FLOAT64)
 pvalue:
   - test:
     input: CAST(0.3 AS FLOAT64), CAST(2 AS INT64)


### PR DESCRIPTION
@jrossthomson @boaguilar I just did a little bit of experimentation to wrap the `jstat` library in a single UDF  — at first pass, it seems that this unfortunately won't be possible for all jStat methods, but maybe achievable for those that take a list of floats as their arguments and return a single scalar float.

My naive attempt was to do something like below, where `args` is an array of arguments to pass to the jstat function:
```sql
CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ANY TYPE)
RETURNS ANY TYPE
LANGUAGE js AS """
    const methodPath = method.split('.')
    let fn = jstat['jStat']
    for (const name of methodPath){
        fn = fn[name]
    }
   
  return fn(...args)
"""
OPTIONS (
	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
);
```

You would invoke the method like so:
```sql
SELECT fns.jstat('chisquare.cdf',  ARRAY<FLOAT64>[0.3, 2.0])
```

However, the `ANY_TYPE` parameter is currently [only supported in SQL UDFs](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#templated-sql-udf-parameters), not JS UDFs. Moreover, `ANY_TYPE` isn't supported as the return type for UDFs.

Many of the [jstat functions](https://jstat.github.io/all.html) expect floats as their input and return a single float scalar, so we _could_ implement this for just those cases, which is what I've done here. Not sure if we want to merge this, or maybe others have an idea of a better approach.

The function implemented in this PR is as below:

```sql
CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ARRAY<FLOAT64>)
RETURNS FLOAT64
LANGUAGE js AS """
    const methodPath = method['split']('.')
    let fn = jstat['jStat']
    for (const name of methodPath){
        fn = fn[name]
    }

  return fn(...args)
"""
OPTIONS (
	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
);

```
